### PR TITLE
Toolbar fix

### DIFF
--- a/ZSSRichTextEditor/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/ZSSRichTextEditor.m
@@ -236,6 +236,10 @@ static Class hackishFixClass = Nil;
 
 }
 
+- (void)viewDidDisappear:(BOOL)animated {
+    [self.toolbar removeFromSuperview];
+    [self.toolbarHolder removeFromSuperview];
+}
 
 - (void)setEnabledToolbarItems:(ZSSRichTextEditorToolbar)enabledToolbarItems {
     

--- a/ZSSRichTextEditor/ZSSRichTextEditor.m
+++ b/ZSSRichTextEditor/ZSSRichTextEditor.m
@@ -237,6 +237,7 @@ static Class hackishFixClass = Nil;
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
     [self.toolbar removeFromSuperview];
     [self.toolbarHolder removeFromSuperview];
 }


### PR DESCRIPTION
Each time the view opened a new toolbar was getting added and wasn't getting destroyed. Now, when the editor view disappears, the toolbar and toolbar holder are removed from the superview.